### PR TITLE
Add workflow to automatically assign pr to creator

### DIFF
--- a/.github/workflows/auto-assign-pull-request.yml
+++ b/.github/workflows/auto-assign-pull-request.yml
@@ -1,0 +1,11 @@
+on:
+  pull_request:
+    types: [opened, reopened]
+name: Assign PR to Creator
+jobs:
+  assignAuthor:
+    name: Assign PR to Creator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign PR to Creator
+        uses: technote-space/assign-author@v1


### PR DESCRIPTION
### Workflow to automatically assign pr to creator

This .yml leveraging an action from the GitHub marketplace ensuring reliability and reduces potential errors in our workflows